### PR TITLE
Add description for usage of WP_CACHE_KEY_SALT

### DIFF
--- a/multiple-sites/.env.deployer
+++ b/multiple-sites/.env.deployer
@@ -19,5 +19,9 @@ AUTH_SALT='generateme'
 SECURE_AUTH_SALT='generateme'
 LOGGED_IN_SALT='generateme'
 NONCE_SALT='generateme'
+
+# Setting variable when same redis server is used for discreet WP installs 
+# on same server with Redis object caching enabled. Setting unqiue values
+# for WP_CACHE_KEY_SALT per site will be mandatory in this case.
 WP_CACHE_KEY_SALT='example.com:' #trailing `:` is important
 


### PR DESCRIPTION
Added description for usage of `WP_CACHE_KEY_SALT` variable in `.env.deployer` file.

Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>